### PR TITLE
Use quotes for queries where a label has multiple words

### DIFF
--- a/gh_client.rb
+++ b/gh_client.rb
@@ -72,7 +72,7 @@ start_date = Date.parse(opts[:start_date]).strftime("%Y-%m-%d")
 end_date = Date.parse(opts[:end_date]).strftime("%Y-%m-%d")
 
 query = "repo:#{opts[:repo]} is:issue "
-query += "label:#{opts[:labels]} " if !opts[:labels].nil?
+query += "label:\"#{opts[:labels]}\" " if !opts[:labels].nil?
 query += "#{opts[:event]}:#{start_date}..#{end_date}"
 
 puts "Github filter query used: " + query


### PR DESCRIPTION
Need to use `"` for labels that have multiple words e.g. "Customer Support"

Before fix: 
```
% bundle exec ruby gh_client.rb -r 'himaxwell/maxwell' -e "closed" -l "Customer Support" -s '2022-4-01' -n '2022-4-30'
Github filter query used: repo:himaxwell/maxwell is:issue label:Customer Support closed:2022-04-01..2022-04-30
0 issues tagged with Customer Support were closed between 2022-04-01 and 2022-04-30
```

After fix: 

```
 % bundle exec ruby gh_client.rb -r 'himaxwell/maxwell' -e "closed" -l "Customer Support" -s '2022-4-01' -n '2022-4-30'
Github filter query used: repo:himaxwell/maxwell is:issue label:"Customer Support" closed:2022-04-01..2022-04-30
5 issues tagged with Customer Support were closed between 2022-04-01 and 2022-04-30
```